### PR TITLE
Add horizontal and vertical guidelines when hitting `a`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Hover over one of the rulers and start dragging a new guide line from there, lik
 2. Hold down <kbd>Ctrl</kbd>.
 
 ## Changelog
+- **v1.5.4 (2019-10-10)**
+    - Add horizontal and vertical guidelines with <kbd>Alt</kbd>+<kbd>A</kbd>
 - **v1.5.3 (2019-10-08)**
     - Toggle guides individually from menu
 - **v1.5.2 (2018-06-08)**

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Hover over one of the rulers and start dragging a new guide line from there, lik
 
 - <kbd>Alt</kbd>+<kbd>H</kbd> adds a *horizontal* guide line at your cursor position and selects it for keyboard movement.
 - <kbd>Alt</kbd>+<kbd>V</kbd> adds a *vertical* guide line at your cursor position and selects it for keyboard movement.
+- <kbd>Alt</kbd>+<kbd>A</kbd> adds a *horizontal* and a *vertical* guide line at your cursor position.
 
 ### Move guide lines with keyboard
 

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -287,12 +287,21 @@ oPageLiner.addHelpLineWithShortcuts = function (e) {
 
     var $oHelpLine = null;
 
+    // keyboard code `h`
     if (e.keyCode === 72) {
         debug('add horizontal helpline');
         $oHelpLine = $(oPageLiner.addHelpLine(0, oPageLiner.mousePosition.y, '#33ffff'));
-    } else if (e.keyCode === 86) {
+    }
+    // keyboard code `v`
+    else if (e.keyCode === 86) {
         debug('add vertical helpline');
         $oHelpLine = $(oPageLiner.addHelpLine(oPageLiner.mousePosition.x, 0, '#33ffff'));
+    } 
+    // keyboard code `a`
+    else if (e.keyCode === 65) {
+        debug('add horizontal and vertical helpline');
+        $(oPageLiner.addHelpLine(0, oPageLiner.mousePosition.y, '#33ffff'));
+        $(oPageLiner.addHelpLine(oPageLiner.mousePosition.x, 0, '#33ffff'));
     }
 
     if ($oHelpLine === null) {


### PR DESCRIPTION
Hey 👋 
Thanks for your chrome extension, it's really useful! 📐

I realized that I sometimes want to add both horizontal and vertical guidelines at the same time, to better measure edges, so I added this functionality.

What do you think? 


![Oct-09-2019 23-54-14](https://user-images.githubusercontent.com/7509765/66523463-5758d180-eaf0-11e9-827b-1ced23b211d2.gif)

