### PR TITLE
Toggle visibility of guidelines and rulers with shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Hover over one of the rulers and start dragging a new guide line from there, lik
 1. Hover over a guide line.
 2. Hold down <kbd>Ctrl</kbd>.
 
+### Show and hide guidelines and rulers with shortcuts
+- <kbd>Alt</kbd>+<kbd>G</kbd> toggles the visibility of the guidlines.
+- <kbd>Alt</kbd>+<kbd>R</kbd> toggles the visibility of the rulers.
+
 ## Changelog
 - **v1.5.3 (2019-10-08)**
     - Toggle guides individually from menu

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Hover over one of the rulers and start dragging a new guide line from there, lik
 - <kbd>Alt</kbd>+<kbd>R</kbd> toggles the visibility of the rulers.
 
 ## Changelog
+- **v1.5.4 (2019-10-10)**
+    - Toggle visibility of guidelines with <kbd>Alt</kbd>+<kbd>G</kbd
+    - Toggle visibility of rulers with <kbd>Alt</kbd>+<kbd>R</kbd
 - **v1.5.3 (2019-10-08)**
     - Toggle guides individually from menu
 - **v1.5.2 (2018-06-08)**

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -287,12 +287,25 @@ oPageLiner.addHelpLineWithShortcuts = function (e) {
 
     var $oHelpLine = null;
 
+    // keyboard code `h`
     if (e.keyCode === 72) {
         debug('add horizontal helpline');
         $oHelpLine = $(oPageLiner.addHelpLine(0, oPageLiner.mousePosition.y, '#33ffff'));
-    } else if (e.keyCode === 86) {
+    }
+    // keyboard code `v`
+    else if (e.keyCode === 86) {
         debug('add vertical helpline');
         $oHelpLine = $(oPageLiner.addHelpLine(oPageLiner.mousePosition.x, 0, '#33ffff'));
+    }
+    // keyboard code `r`
+    else if (e.keyCode === 82) {
+        debug('toggle rulers');
+        oPageLiner.toggleRulers();
+    }
+    // keyboard code `g`
+    else if (e.keyCode === 71) {
+        debug('toggle guidelines');
+        oPageLiner.toggleHelplines();
     }
 
     if ($oHelpLine === null) {

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -108,8 +108,8 @@ oPageLiner.init = function () {
         }
     }
 
-    $window.unbind('keydown', oPageLiner.addHelpLineWithShortcuts);
-    $window.on('keydown', oPageLiner.addHelpLineWithShortcuts);
+    $window.unbind('keydown', oPageLiner.handleKeyboardShortcuts);
+    $window.on('keydown', oPageLiner.handleKeyboardShortcuts);
 
     debug('[PageLiner] Initializing done.');
 };
@@ -280,7 +280,7 @@ oPageLiner.addHelpLineToDOM = function (posX, posY, sColor, iHelplineIndex) {
     return oHelpLineElem;
 };
 
-oPageLiner.addHelpLineWithShortcuts = function (e) {
+oPageLiner.handleKeyboardShortcuts = function (e) {
     if (!e.altKey || e.ctrlKey || e.shiftKey) {
         return;
     }


### PR DESCRIPTION
Hey 👋 
when doing the changes in the first PR I thought it would be cool to toggle the rulers and guidelines with a keyboard shortcut, so one does not always have to open the extension popup.

What do you think about this? 😄 

![Oct-10-2019 00-26-59](https://user-images.githubusercontent.com/7509765/66525117-c1737580-eaf4-11e9-97c0-c5057dc1e69b.gif)
